### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,9 @@
 name: Build and Push Docker Image
 
+permissions:
+  contents: read
+  packages: write
+
 on:
   push:
     branches:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,4 +1,6 @@
 name: Tests
+permissions:
+  contents: read
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/julienc91/ezshare/security/code-scanning/3](https://github.com/julienc91/ezshare/security/code-scanning/3)

To fix the problem, add a `permissions` block to the workflow at the top level (recommended) so that all jobs default to least-privilege, unless a specific job requires broader permissions. The required permissions for pushing to GitHub Container Registry and deleting containers are generally `contents: read` (to access repository content), and `packages: write` (to publish/delete packages/images via the registry). Set these as the minimal required permissions at the workflow root, above the `jobs:` section. No additional imports or code changes outside this shown snippet are necessary.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
